### PR TITLE
support for Civic gatekeeper if present in guards

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@civic/solana-gateway-react": "^0.10.0",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.60",

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -534,7 +534,6 @@ const Home = (props: HomeProps) => {
                     clusterUrl={connection.rpcEndpoint}
                     cluster={process.env.NEXT_PUBLIC_SOLANA_NETWORK || 'devnet'}
                     options={{ autoShowModal: false }}
-                    stage="dev"
                   >
                     <MultiMintButton
                     candyMachine={candyMachine}

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -21,6 +21,7 @@ import Countdown from "react-countdown";
 import { useEffect, useMemo, useState } from "react";
 import styled from "styled-components";
 import { MintCounterBorsh } from "./borsh/mintCounter";
+import { GatewayProvider } from "@civic/solana-gateway-react";
 
 import { MintButton } from "./MintButton";
 import {
@@ -353,6 +354,7 @@ const Home = (props: HomeProps) => {
     isPresale,
   ]);
 
+  const gatekeeperNetwork = candyMachine?.candyGuard?.guards?.gatekeeper?.network;
   return (
     <main>
       <>
@@ -439,9 +441,30 @@ const Home = (props: HomeProps) => {
                 <ConnectButton>Connect Wallet</ConnectButton>
               ) : !isWLOnly || whitelistTokenBalance > 0 ? (
                 <>
-                  <MintButton
+
+              <div>
+                {!!itemsRemaining &&
+                candyMachine?.candyGuard?.guards.gatekeeper &&
+                wallet.publicKey &&
+                wallet.signTransaction ? (
+                  <GatewayProvider
+                    wallet={{
+                      publicKey:
+                        wallet.publicKey,
+                      //@ts-ignore
+                      signTransaction: wallet.signTransaction,
+                    }}
+                    gatekeeperNetwork={gatekeeperNetwork}
+                    clusterUrl={connection.rpcEndpoint}
+                    cluster={process.env.NEXT_PUBLIC_SOLANA_NETWORK || 'devnet'}
+                    options={{ autoShowModal: false }}
+                    stage="dev"
+                  >
+                    <MintButton
                     candyMachine={candyMachine}
+                    gatekeeperNetwork={gatekeeperNetwork}
                     isMinting={isMinting}
+                    setIsMinting={setIsMinting}
                     isActive={!!itemsRemaining}
                     isEnded={isEnded}
                     isSoldOut={!itemsRemaining}
@@ -457,6 +480,29 @@ const Home = (props: HomeProps) => {
                     onMint={startMint}
                     // price={0}
                   />
+                  </GatewayProvider>
+                ) : (
+                  <MintButton
+                    candyMachine={candyMachine}
+                    isMinting={isMinting}
+                    setIsMinting={setIsMinting}
+                    isActive={!!itemsRemaining}
+                    isEnded={isEnded}
+                    isSoldOut={!itemsRemaining}
+                    limitReached={
+                      !!(
+                        guards?.mintLimit?.settings?.limit &&
+                        !(
+                          (guards?.mintLimit?.mintCounter?.count || 0) <
+                          guards?.mintLimit?.settings?.limit
+                        )
+                      )
+                    }
+                    onMint={startMint}
+                    // price={0}
+                  />
+                )}
+              </div>
                 </>
               ) : (
                 <h1>Mint is private.</h1>

--- a/src/MintButton.tsx
+++ b/src/MintButton.tsx
@@ -1,8 +1,19 @@
+import { GatewayStatus, useGateway } from "@civic/solana-gateway-react";
 import { CircularProgress } from "@material-ui/core";
 import Button from "@material-ui/core/Button";
 import { CandyMachine } from "@metaplex-foundation/js";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import styled from "styled-components";
+import { useConnection, useWallet } from "@solana/wallet-adapter-react";
+import { PublicKey } from "@solana/web3.js";
+
+function usePrevious<T>(value: T): T | undefined {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  }, [value]);
+  return ref.current;
+}
 
 export const CTAButton = styled(Button)`
   display: block !important;
@@ -16,29 +27,66 @@ export const MintButton = ({
   onMint,
   candyMachine,
   isMinting,
+  setIsMinting,
   isEnded,
   isActive,
   isSoldOut,
-  limitReached
+  limitReached,
+  gatekeeperNetwork
 }: {
   onMint: (quantityString: number) => Promise<void>;
   candyMachine: CandyMachine | undefined;
   isMinting: boolean;
+  setIsMinting: (val: boolean) => void;
   isEnded: boolean;
   isActive: boolean;
   isSoldOut: boolean;
   limitReached: boolean;
+  gatekeeperNetwork?: PublicKey;
 }) => {
+  const { requestGatewayToken, gatewayStatus } = useGateway();
   const [loading, setLoading] = useState(false);
+  const [waitForActiveToken, setWaitForActiveToken] = useState(false);
+
+  const previousGatewayStatus = usePrevious(gatewayStatus);
+  useEffect(() => {
+    const fromStates = [
+      GatewayStatus.NOT_REQUESTED,
+      GatewayStatus.REFRESH_TOKEN_REQUIRED,
+    ];
+    const invalidToStates = [...fromStates, GatewayStatus.UNKNOWN];
+    if (
+      fromStates.find((state) => previousGatewayStatus === state) &&
+      !invalidToStates.find((state) => gatewayStatus === state)
+    ) {
+      setIsMinting(true);
+    }
+    console.log("change: ", GatewayStatus[gatewayStatus]);
+  }, [previousGatewayStatus, gatewayStatus, setIsMinting]);
+
+  useEffect(() => {
+    if (waitForActiveToken && gatewayStatus === GatewayStatus.ACTIVE) {
+      console.log("Minting after token active");
+      setWaitForActiveToken(false);
+      onMint(1);
+    }
+  }, [waitForActiveToken, gatewayStatus, onMint]);
 
   return (
     <CTAButton
       disabled={loading || isSoldOut || isMinting || isEnded || !isActive || limitReached}
       onClick={async () => {
-        console.log("Minting...");
-        setLoading(true);
-        await onMint(1);
-        setLoading(false);
+        if (isActive && gatekeeperNetwork) {
+          if (gatewayStatus === GatewayStatus.ACTIVE) {
+            await onMint(1);
+          } else {
+            setWaitForActiveToken(true);
+            await requestGatewayToken();
+          }
+          
+        } else {
+          await onMint(1);
+        }
       }}
       variant="contained"
     >

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -24,7 +24,6 @@ const network = (process.env.NEXT_PUBLIC_SOLANA_NETWORK ||
   WalletAdapterNetwork.Mainnet) as WalletAdapterNetwork;
 // const network = WalletAdapterNetwork.Devnet;
 const rpcHost = process.env.NEXT_PUBLIC_RPC_HOST || clusterApiUrl(network);
-
 const theme = createTheme({
   palette: {
     type: "dark",

--- a/yarn.lock
+++ b/yarn.lock
@@ -172,6 +172,27 @@
     near-api-js "^0.44.2"
     near-seed-phrase "^0.2.0"
 
+"@civic/common-gateway-react@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@civic/common-gateway-react/-/common-gateway-react-0.5.0.tgz#b9ea5df8e47822874c620213293f058c0883c32b"
+  integrity sha512-vgUKxTZViDB82fOnJ6dLl0KnG7M7V39vKoT7YtLt+vijlo8JjUdT2s6agp8RfZ3aK92fELg71bgEv68tee+Huw==
+  dependencies:
+    fetch-retry-ts "^1.1.24"
+    iframe-resizer-react "^1.1.0"
+    ramda "^0.27.1"
+    styled-components "^5.3.1"
+
+"@civic/solana-gateway-react@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@civic/solana-gateway-react/-/solana-gateway-react-0.10.0.tgz#5d0954414792bc82036a1a79eb61f9713b0ab091"
+  integrity sha512-WYYv7z3EvjJm4AAuReyz7j8t0mpY8DrnZ+CN6rwQ/SuFTmBQ4oKtTBANNlLOLDJp19GAHceTWvbHRwrY0CygYQ==
+  dependencies:
+    "@civic/common-gateway-react" "^0.5.0"
+    "@identity.com/prove-solana-wallet" "^0.3.1"
+    "@identity.com/solana-gateway-ts" "0.9.0"
+    "@solana/web3.js" "^1.63.0"
+    ramda "^0.28.0"
+
 "@emotion/hash@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
@@ -605,6 +626,26 @@
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
+
+"@identity.com/prove-solana-wallet@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@identity.com/prove-solana-wallet/-/prove-solana-wallet-0.3.1.tgz#759e65c8f966c3492c3edd96e5112b73d9557a3d"
+  integrity sha512-OHep3nmXUYeDdDEejxyp5/GHk1yW2d9EG3tN/7j3BN+7V4YBgUQPNMhy3sfDrj/QCUmpxHs9B05RN5SD9bm23Q==
+  dependencies:
+    "@solana/web3.js" "^1.63.1"
+    bs58 "^4.0.1"
+
+"@identity.com/solana-gateway-ts@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@identity.com/solana-gateway-ts/-/solana-gateway-ts-0.9.0.tgz#23ce316f1cfd3b30e84bde31079de53e81f26c8f"
+  integrity sha512-aTq3TOth5KF9Nfw64XxDHFOqyhXlpzp1L/WpeOsmYlVIMdtgIvJFZEJMix4Q6Tr7BXzVXHAfXr5VVwkGOp4t1A==
+  dependencies:
+    "@solana/web3.js" "^1.63.0"
+    async-retry "^1.3.3"
+    bn.js "^5.2.0"
+    borsh "^0.4.0"
+    bs58 "^5.0.0"
+    ramda "^0.27.1"
 
 "@jnwng/walletconnect-solana@^0.1.3":
   version "0.1.4"
@@ -1640,7 +1681,7 @@
   dependencies:
     "@solana/wallet-adapter-base" "^0.9.18"
 
-"@solana/web3.js@^1.32.0", "@solana/web3.js@^1.35.1", "@solana/web3.js@^1.36.0", "@solana/web3.js@^1.44.3", "@solana/web3.js@^1.56.2", "@solana/web3.js@^1.63.1", "@solana/web3.js@^1.66.2":
+"@solana/web3.js@^1.32.0", "@solana/web3.js@^1.35.1", "@solana/web3.js@^1.36.0", "@solana/web3.js@^1.44.3", "@solana/web3.js@^1.56.2", "@solana/web3.js@^1.63.0", "@solana/web3.js@^1.63.1", "@solana/web3.js@^1.66.2":
   version "1.66.2"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.66.2.tgz#80b43c5868b846124fe3ebac7d3943930c3fa60c"
   integrity sha512-RyaHMR2jGmaesnYP045VLeBGfR/gAW3cvZHzMFGg7bkO+WOYOYp1nEllf0/la4U4qsYGKCsO9eEevR5fhHiVHg==
@@ -1936,6 +1977,13 @@
     lodash-es "^4.17.21"
     loglevel "^1.8.0"
     pump "^3.0.0"
+
+"@types/bn.js@^4.11.5":
+  version "4.11.6"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"
+  integrity sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/bn.js@^5.1.0":
   version "5.1.1"
@@ -2711,6 +2759,16 @@ bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.1.2, bn.js@^5.2.0, bn.js@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
   integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
+
+borsh@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/borsh/-/borsh-0.4.0.tgz#9dd6defe741627f1315eac2a73df61421f6ddb9f"
+  integrity sha512-aX6qtLya3K0AkT66CmYWCCDr77qsE9arV05OmdFpmat9qu8Pg9J5tBUPDztAW5fNh/d/MyVG/OYziP52Ndzx1g==
+  dependencies:
+    "@types/bn.js" "^4.11.5"
+    bn.js "^5.0.0"
+    bs58 "^4.0.0"
+    text-encoding-utf-8 "^1.0.2"
 
 borsh@^0.6.0:
   version "0.6.0"
@@ -3949,6 +4007,11 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
+fetch-retry-ts@^1.1.24:
+  version "1.1.25"
+  resolved "https://registry.yarnpkg.com/fetch-retry-ts/-/fetch-retry-ts-1.1.25.tgz#25849a87a5a016cc772f90986d95dd5049eeb5ac"
+  integrity sha512-kjJcfBYDbajnxMBfBa85hrS0Z+A0bDKuZWuzh5uHpaLSm2qZ3eAND5sDVfFUuIJg51sTd91cdB+Ayqo3magB/g==
+
 figures@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
@@ -4288,6 +4351,19 @@ ieee754@^1.1.13, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
+iframe-resizer-react@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/iframe-resizer-react/-/iframe-resizer-react-1.1.0.tgz#5009e019b7a5c7f1c009bff5bcdf0dbf33557465"
+  integrity sha512-FrytSq91AIJaDgE+6uK/Vdd6IR8CrwLoZ6eGmL2qQMPTzF0xlSV2jaSzRRUh5V2fttD7vzl21jvBl97bV40eBw==
+  dependencies:
+    iframe-resizer "^4.3.0"
+    warning "^4.0.3"
+
+iframe-resizer@^4.3.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/iframe-resizer/-/iframe-resizer-4.3.2.tgz#42dd88345d18b9e377b6044dddb98c664ab0ce6b"
+  integrity sha512-gOWo2hmdPjMQsQ+zTKbses08mDfDEMh4NneGQNP4qwePYujY1lguqP6gnbeJkf154gojWlBhIltlgnMfYjGHWA==
 
 ignore@^5.2.0:
   version "5.2.0"
@@ -5562,6 +5638,16 @@ quick-format-unescaped@^4.0.1, quick-format-unescaped@^4.0.3:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz#93ef6dd8d3453cbc7970dd614fad4c5954d6b5a7"
   integrity sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==
+
+ramda@^0.27.1:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.2.tgz#84463226f7f36dc33592f6f4ed6374c48306c3f1"
+  integrity sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA==
+
+ramda@^0.28.0:
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.28.0.tgz#acd785690100337e8b063cab3470019be427cc97"
+  integrity sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==
 
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
This PR adds support for Candy Machine V3 mints that are protected by a Civic gatekeeper set in their candy machine guard. The value for the gatekeeper comes directly from on-chain information from the Candy Machine instance.

The changes are based on the Candy Machine V2 reference implementation: https://github.com/metaplex-foundation/candy-machine-ui