### PR TITLE
Fix for Phantom Wallet's last version (re-assign signed transactions)

### DIFF
--- a/src/hooks/useCandyMachineV3.tsx
+++ b/src/hooks/useCandyMachineV3.tsx
@@ -226,7 +226,7 @@ export default function useCandyMachineV3(
         let signedTransactions = transactions;
 
         for (let signer in signers) {
-          await signers[signer].signAllTransactions(transactions);
+          signedTransactions = await signers[signer].signAllTransactions(transactions);
         }
         if (allowList) {
           const allowListCallGuardRouteTx = signedTransactions.shift();


### PR DESCRIPTION
Phantom requires returned transactions to be re-assigned. 

A small fix!